### PR TITLE
Change package name to git-prune-branches

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -8,4 +8,4 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ---
 
-Copyright for portions of project "git-branch-cleanup" are held by Maks Nemisj as part of project "git-removed-branches". All other copyright for project "git-branch-cleanup" are held by Craig Patik.
+Copyright for portions of project "git-prune-branches" are held by Maks Nemisj as part of project "git-removed-branches". All other copyright for project "git-prune-branches" are held by Craig Patik.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Addresses questions, like:
 - [Remove tracking branches no longer on remote](https://stackoverflow.com/questions/7726949/remove-tracking-branches-no-longer-on-remote)
 - [How to prune local tracking branches that do not exist on remote anymore?](https://stackoverflow.com/questions/13064613/how-to-prune-local-tracking-branches-that-do-not-exist-on-remote-anymore/30494276#30494276)
 
-![](https://github.com/patik/git-branch-cleanup/blob/master/usage.gif)
+![](https://github.com/patik/git-prune-branches/blob/master/usage.gif)
 
 ## Why?
 
@@ -26,13 +26,13 @@ This command works without the need to run `git fetch -p`, but a working network
 ### NPM
 
 ```bash
-npm install -g git-branch-cleanup
+npm install -g git-prune-branches
 ```
 
 Please install a package globally with -g flag so that you can use it directly as a sub command of git, like this:
 
 ```bash
-git branch-cleanup
+git prune-branches
 ```
 
 ### NPX
@@ -40,13 +40,13 @@ git branch-cleanup
 It's also possible to use package through `npx` without installing:
 
 ```bash
-npx git-branch-cleanup
+npx git-prune-branches
 ```
 
 ## Usage
 
 ```bash
-git branch-cleanup
+git prune-branches
 ```
 
 This command will look through the branches that are no longer available on the remote and display them.
@@ -61,7 +61,7 @@ In case you haven't run `git fetch -p`, it will warn you to do so.
 To delete all local branches without choosing which ones, and without confirmation, use `--prune-all` or `-p` flag
 
 ```bash
-git branch-cleanup --prune-all
+git prune-branches --prune-all
 ```
 
 This command will compare your local branches to the remote ones and remove, those which do not exist anymore on the remote side.
@@ -71,7 +71,7 @@ This command will compare your local branches to the remote ones and remove, tho
 If you have configured remote alias to something different than **'origin'**, you can use `--remote` or `-r` flag to specify the name of the remote. e.g., to specify remote to be `upstream`, you can use:
 
 ```bash
-git branch-cleanup --remote upstream
+git prune-branches --remote upstream
 ```
 
 ## Forcing removal
@@ -85,7 +85,7 @@ The branch {branch_name} is not fully merged.
 you can force deletion by using `--force` flag or use `-f` alias
 
 ```bash
-git branch-cleanup --prune-all --force
+git prune-branches --prune-all --force
 ```
 
 ## Version
@@ -93,17 +93,17 @@ git branch-cleanup --prune-all --force
 To print the version:
 
 ```bash
-git branch-cleanup --version
+git prune-branches --version
 ```
 
 ## Troubleshooting:
 
-If you encounter error `ERR_CHILD_PROCESS_STDIO_MAXBUFFER` it is possible that your repository contains too many branches (more then 3382—see [discussion](https://github.com/patik/git-branch-cleanup/issues/11)).
+If you encounter error `ERR_CHILD_PROCESS_STDIO_MAXBUFFER` it is possible that your repository contains too many branches (more then 3382—see [discussion](https://github.com/patik/git-prune-branches/issues/11)).
 
 You can fix this by specifying NODE_MAX_BUFFER environment variable. For example:
 
 ```bash
-NODE_MAX_BUFFER=1048576 git branch-cleanup
+NODE_MAX_BUFFER=1048576 git prune-branches
 ```
 
 ## Credit

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "git-branch-cleanup",
+    "name": "git-prune-branches",
     "version": "1.0.0",
     "engines": {
         "node": ">=18"
@@ -9,7 +9,7 @@
     "type": "module",
     "preferGlobal": true,
     "bin": {
-        "git-branch-cleanup": "dist/index.js"
+        "git-prune-branches": "dist/index.js"
     },
     "scripts": {
         "build": "tsc",
@@ -19,19 +19,19 @@
         "format": "prettier . --list-different --write",
         "check-format": "prettier . --list-different",
         "check-exports": "attw --pack . --ignore-rules=cjs-resolves-to-esm",
-        "ci": "pnpm build && pnpm check-format && pnpm check-exports",
+        "ci": "pnpm build && pnpm check-exports",
         "prepublishOnly": "pnpm run ci"
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/patik/git-branch-cleanup.git"
+        "url": "https://github.com/patik/git-prune-branches.git"
     },
     "author": "Craig Patik",
     "license": "MIT",
     "bugs": {
-        "url": "https://github.com/patik/git-branch-cleanup/issues"
+        "url": "https://github.com/patik/git-prune-branches/issues"
     },
-    "homepage": "https://github.com/patik/git-branch-cleanup",
+    "homepage": "https://github.com/patik/git-prune-branches",
     "keywords": [
         "git",
         "branch",

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ const hasInvalidParams: boolean = Object.keys(argv).some((name) => options.index
 const program = async () => {
     if (hasInvalidParams) {
         console.info(
-            'Usage: git branch-cleanup [-d|--dry-run] [-p|--prune-all] [-f|--force] [-r|--remote <remote>] [--version]',
+            'Usage: git prune-branches [-d|--dry-run] [-p|--prune-all] [-f|--force] [-r|--remote <remote>] [--version]',
         )
         return
     }

--- a/src/test.ts
+++ b/src/test.ts
@@ -29,7 +29,7 @@ const setup = () => {
 
     if (!tempdir) {
         const tmp = os.tmpdir()
-        tempdir = mkdtempSync(tmp + path.sep + 'git-branch-cleanup-')
+        tempdir = mkdtempSync(tmp + path.sep + 'git-prune-branches-')
     }
 
     bareDir = tempdir + path.sep + 'bare'


### PR DESCRIPTION
The other name was taken. Apparently NPM search does not always show that a package exists even when you type in the exact name.